### PR TITLE
rename Vis to Pod in UI and code; add tooltip for pod

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -40,7 +40,7 @@ enum TimeRangeSource {
   PANEL = 'panel'
 }
 
-enum Visualization {
+enum Pod {
   LINE = 'line',
   BAR = 'bar'
 }
@@ -74,7 +74,7 @@ class ChartwerkCtrl extends MetricsPanelCtrl {
     confidence: 0,
     timeInterval: undefined,
     override: '',
-    visualization: Visualization.LINE,
+    pod: Pod.LINE,
     lineMode: Mode.STANDARD,
     displayWarnings: false,
     upperBound: '',
@@ -85,7 +85,7 @@ class ChartwerkCtrl extends MetricsPanelCtrl {
   tooltip?: GraphTooltip;
   ticksOrientation = _.map(TickOrientation, (name: string) => name);
   timeRangeSources = _.map(TimeRangeSource, (name: string) => name);
-  visualizationTypes = _.map(Visualization, (name: string) => name);
+  podTypes = _.map(Pod, (name: string) => name);
   mode = _.map(Mode, (name: string) => name);
   warning = '';
 
@@ -242,7 +242,7 @@ class ChartwerkCtrl extends MetricsPanelCtrl {
   onInitEditMode(): void {
     this.addEditorTab('Visualization', `${PARTIALS_PATH}/tab_visualization.html`, 2);
     this.addEditorTab('Axes', `${PARTIALS_PATH}/tab_axes.html`, 3);
-    if(this.visualization === Visualization.LINE) {
+    if(this.pod === Pod.LINE) {
       this.addEditorTab('Confidence', `${PARTIALS_PATH}/tab_confidence.html`, 4);
     }
     this.addEditorTab('Template variables', `${PARTIALS_PATH}/tab_template_variables.html`, 5);
@@ -253,17 +253,17 @@ class ChartwerkCtrl extends MetricsPanelCtrl {
     this.updateSeriesVariables();
     this.getVisibleForSeries();
 
-    switch(this.visualization) {
-      case Visualization.LINE:
+    switch(this.pod) {
+      case Pod.LINE:
         this.chart = new ChartwerkLineChart(this.chartContainer, this.series as any, this.chartOptions);
         break;
 
-      case Visualization.BAR:
+      case Pod.BAR:
         this.chart = new ChartwerkBarChart(this.chartContainer, this.series as any, this.chartOptions);
         break;
 
       default:
-        throw new Error(`Uknown visualization type: ${this.visualization}`);
+        throw new Error(`Uknown pod type: ${this.pod}`);
     }
   }
 
@@ -615,12 +615,12 @@ class ChartwerkCtrl extends MetricsPanelCtrl {
     this.panel.lowerBound = alias;
   }
 
-  get visualization(): Visualization {
-    return this.panel.visualization;
+  get pod(): Pod {
+    return this.panel.pod;
   }
 
-  set visualization(alias: Visualization) {
-    this.panel.visualization = alias;
+  set pod(value: Pod) {
+    this.panel.pod = value;
   }
 
   // TODO: not "| undefined"

--- a/src/partials/tab_visualization.html
+++ b/src/partials/tab_visualization.html
@@ -1,15 +1,23 @@
 <div class="gf-form">
-  <label class="gf-form-label query-keyword width-12"> Visualization </label>
+  <label class="gf-form-label query-keyword width-12">
+    <div class="gf-form-help-icon gf-form-help-icon--right-normal">
+      <i
+        class="fa fa-info-circle"
+        bs-tooltip="'Pod is visualization &quot;panel&quot;/&quot;plugin&quot; in Chartwerk`s terminology.'"
+      ></i>
+    </div>
+    Pod
+  </label>
   <div class="gf-form-select-wrapper">
     <select class="gf-form-input width-12"
-      ng-model="ctrl.visualization"
-      ng-options="visualization for visualization in ctrl.visualizationTypes"
+      ng-model="ctrl.pod"
+      ng-options="pod for pod in ctrl.podTypes"
       ng-change="ctrl.onConfigChange()"
     />
   </div>
 </div>
 
-<div class="gf-form" ng-if="ctrl.visualization === 'line'">
+<div class="gf-form" ng-if="ctrl.pod === 'line'">
   <label class="gf-form-label query-keyword width-12"> Mode </label>
   <div class="gf-form-select-wrapper">
     <select class="gf-form-input width-12"


### PR DESCRIPTION
closes https://github.com/chartwerk/grafana-chartwerk-panel/issues/30


Now it looks like this: 
![image](https://user-images.githubusercontent.com/1022757/83947011-b18f6b00-a814-11ea-86a3-0b796803d5e6.png)

## Changes
* rename "visualisation" word to "pod" in the code (so in UI)
* add tooltip (see the screenshot)
